### PR TITLE
L2+ Linf unreliability flags updated

### DIFF
--- a/cifar10/L2.html
+++ b/cifar10/L2.html
@@ -125,7 +125,7 @@
         <td class="aatd">78.79%</td>
         
         <td class="aa-extd">78.79%</td>
-        <td class="flagsd">Unknown</td>
+        <td class="flagsd"><div class="flagsd-emoji">&#215;</div></td>
         
         <td class="datatd">&#9745;</td>
         <td class="archtd">WideResNet-34-10</td>
@@ -147,7 +147,7 @@
         <td class="aatd">76.25%</td>
         
         <td class="aa-extd">76.25%</td>
-        <td class="flagsd">Unknown</td>
+        <td class="flagsd"><div class="flagsd-emoji">&#215;</div></td>
         
         <td class="datatd">&#9745;</td>
         <td class="archtd">WideResNet-34-10</td>
@@ -191,7 +191,7 @@
         <td class="aatd">76.12%</td>
         
         <td class="aa-extd">76.12%</td>
-        <td class="flagsd">Unknown</td>
+        <td class="flagsd"><div class="flagsd-emoji">&#215;</div></td>
         
         <td class="datatd">&#215;</td>
         <td class="archtd">WideResNet-34-10</td>
@@ -269,7 +269,7 @@
         <td class="aatd">73.39%</td>
         
         <td class="aa-extd">73.39%</td>
-        <td class="flagsd">Unknown</td>
+        <td class="flagsd"><div class="flagsd-emoji">&#215;</div></td>
         
         <td class="datatd">&#215;</td>
         <td class="archtd">ResNet-18</td>
@@ -308,7 +308,7 @@
         <td class="aatd">69.24%</td>
         
         <td class="aa-extd">69.24%</td>
-        <td class="flagsd">Unknown</td>
+        <td class="flagsd"><div class="flagsd-emoji">&#215;</div></td>
         
         <td class="datatd">&#215;</td>
         <td class="archtd">ResNet-50</td>
@@ -325,7 +325,7 @@
         <td class="aatd">67.68%</td>
         
         <td class="aa-extd">67.68%</td>
-        <td class="flagsd">Unknown</td>
+        <td class="flagsd"><div class="flagsd-emoji">&#215;</div></td>
         
         <td class="datatd">&#215;</td>
         <td class="archtd">PreActResNet-18</td>
@@ -359,7 +359,7 @@
         <td class="aatd">66.09%</td>
         
         <td class="aa-extd">66.09%</td>
-        <td class="flagsd">Unknown</td>
+        <td class="flagsd"><div class="flagsd-emoji">&#215;</div></td>
         
         <td class="datatd">&#215;</td>
         <td class="archtd">WideResNet-28-4</td>

--- a/cifar10/Linf.html
+++ b/cifar10/Linf.html
@@ -308,7 +308,7 @@
         <td class="aatd">59.53%</td>
         
         <td class="aa-extd">59.53%</td>
-        <td class="flagsd">Unknown</td>
+        <td class="flagsd"><div class="flagsd-emoji">&#215;</div></td>
         
         <td class="datatd">&#9745;</td>
         <td class="archtd">WideResNet-28-10</td>
@@ -330,7 +330,7 @@
         <td class="aatd">59.09%</td>
         
         <td class="aa-extd">59.09%</td>
-        <td class="flagsd">Unknown</td>
+        <td class="flagsd"><div class="flagsd-emoji">&#215;</div></td>
         
         <td class="datatd">&#215;</td>
         <td class="archtd">WideResNet-34-10</td>
@@ -391,7 +391,7 @@
         <td class="aatd">57.14%</td>
         
         <td class="aa-extd">57.14%</td>
-        <td class="flagsd">Unknown</td>
+        <td class="flagsd"><div class="flagsd-emoji">&#215;</div></td>
         
         <td class="datatd">&#9745;</td>
         <td class="archtd">WideResNet-28-10</td>
@@ -474,7 +474,7 @@
         <td class="aatd">56.29%</td>
         
         <td class="aa-extd">56.29%</td>
-        <td class="flagsd">Unknown</td>
+        <td class="flagsd"><div class="flagsd-emoji">&#215;</div></td>
         
         <td class="datatd">&#9745;</td>
         <td class="archtd">WideResNet-28-10</td>
@@ -525,7 +525,7 @@
         <td class="aatd">54.92%</td>
         
         <td class="aa-extd">54.92%</td>
-        <td class="flagsd">Unknown</td>
+        <td class="flagsd"><div class="flagsd-emoji">&#215;</div></td>
         
         <td class="datatd">&#9745;</td>
         <td class="archtd">WideResNet-28-10</td>
@@ -547,7 +547,7 @@
         <td class="aatd">54.43%</td>
         
         <td class="aa-extd">54.43%</td>
-        <td class="flagsd">Unknown</td>
+        <td class="flagsd"><div class="flagsd-emoji">&#215;</div></td>
         
         <td class="datatd">&#215;</td>
         <td class="archtd">ResNet-18</td>
@@ -586,7 +586,7 @@
         <td class="aatd">53.74%</td>
         
         <td class="aa-extd">53.74%</td>
-        <td class="flagsd">Unknown</td>
+        <td class="flagsd"><div class="flagsd-emoji">&#215;</div></td>
         
         <td class="datatd">&#215;</td>
         <td class="archtd">WideResNet-34-20</td>
@@ -625,7 +625,7 @@
         <td class="aatd">53.51%</td>
         
         <td class="aa-extd">53.51%</td>
-        <td class="flagsd">Unknown</td>
+        <td class="flagsd"><div class="flagsd-emoji">&#215;</div></td>
         
         <td class="datatd">&#215;</td>
         <td class="archtd">WideResNet-34-10</td>
@@ -642,7 +642,7 @@
         <td class="aatd">53.42%</td>
         
         <td class="aa-extd">53.42%</td>
-        <td class="flagsd">Unknown</td>
+        <td class="flagsd"><div class="flagsd-emoji">&#215;</div></td>
         
         <td class="datatd">&#215;</td>
         <td class="archtd">WideResNet-34-20</td>


### PR DESCRIPTION
I have updated html's with unreliability flags for the remaining top Linf and all but one L2 models. Let me know if this doesn't work.